### PR TITLE
Added support to parent view controller where the hashtag table view will be displayed

### DIFF
--- a/Classes/UITextView+AVTagTextView.h
+++ b/Classes/UITextView+AVTagTextView.h
@@ -43,6 +43,13 @@
 @property (nonatomic, strong) UITableViewController<AVTagTableViewControllerProtocol> *hashTagsTableViewController;
 
 /**
+ * Parent view controller that will display the 
+ * hashTagsTableViewController. It must be the view controller
+ * where the AVTagTextView is displayed
+ */
+@property (nonatomic, weak) UIViewController *parentViewController;
+
+/**
  * The height of the displayed hash tags table view controller, 
  * measured from the bottom of the iDevice keyboard. Defaults 
  * to DEFAULT_TABLE_VIEW_HEIGHT

--- a/Classes/UITextView+AVTagTextView.m
+++ b/Classes/UITextView+AVTagTextView.m
@@ -130,9 +130,7 @@ static const char *kHashTagsTableViewHeightKey = "hashTagsTableViewHeightKey";
     UITableViewController<AVTagTableViewControllerProtocol> *controller = self.hashTagsTableViewController;
     
     //Add the controller to the current root view controller if it hasn't been added anywhere so far
-    if(!controller.tableView.superview){
-//        UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-        
+    if(!controller.tableView.superview){       
         [controller willMoveToParentViewController:self.parentViewController];
         [self.parentViewController.view addSubview:controller.view];
         [controller didMoveToParentViewController:self.parentViewController];

--- a/Classes/UITextView+AVTagTextView.m
+++ b/Classes/UITextView+AVTagTextView.m
@@ -57,6 +57,20 @@ static const char *kHashTagsTableViewControllerKey = "hashTagsTableViewControlle
     return controller;
 }
 
+static const char *kParentViewControllerKey = "parentViewControllerKey";
+
+- (void)setParentViewController:(UIViewController *)parentViewController
+{
+    if (self.parentViewController != parentViewController) {
+        objc_setAssociatedObject(self, kParentViewControllerKey, parentViewController, OBJC_ASSOCIATION_ASSIGN);
+    }
+}
+
+- (UIViewController *)parentViewController
+{
+    return objc_getAssociatedObject(self, kParentViewControllerKey);
+}
+
 static const char *kHashTagsTableViewHeightKey = "hashTagsTableViewHeightKey";
 
 - (void)setHashTagsTableViewHeight:(CGFloat)hashTagsTableViewHeight{
@@ -117,11 +131,11 @@ static const char *kHashTagsTableViewHeightKey = "hashTagsTableViewHeightKey";
     
     //Add the controller to the current root view controller if it hasn't been added anywhere so far
     if(!controller.tableView.superview){
-        UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+//        UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
         
-        [controller willMoveToParentViewController:rootViewController];
-        [rootViewController.view addSubview:controller.view];
-        [controller didMoveToParentViewController:rootViewController];
+        [controller willMoveToParentViewController:self.parentViewController];
+        [self.parentViewController.view addSubview:controller.view];
+        [controller didMoveToParentViewController:self.parentViewController];
     }
     controller.view.hidden =  tags.count == 0;
     controller.hashTagsToDisplay = tags;

--- a/Project/AVTagTextView.xcodeproj/project.pbxproj
+++ b/Project/AVTagTextView.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2DF201041811E31B00BAB170 /* AVCustomTagTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DF201021811E31B00BAB170 /* AVCustomTagTableViewController.m */; };
 		2DF201051811E31B00BAB170 /* AVCustomTagTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2DF201031811E31B00BAB170 /* AVCustomTagTableViewController.xib */; };
 		2DF201071811E35500BAB170 /* AVTagTextViewSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DF201061811E35500BAB170 /* AVTagTextViewSpec.m */; };
+		382BCD2E18C9DD5000F35CB3 /* AVMainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 382BCD2D18C9DD5000F35CB3 /* AVMainViewController.m */; };
 		4FF60A7CF38F49F1A53F12D7 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8734AF505AF74CD9BF980484 /* libPods.a */; };
 		68CAA5FE50C74F6390AB2B00 /* libPods-AVTagTextViewTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DACF7587EEA47368BAFD0A5 /* libPods-AVTagTextViewTests.a */; };
 /* End PBXBuildFile section */
@@ -60,6 +61,8 @@
 		2DF201021811E31B00BAB170 /* AVCustomTagTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVCustomTagTableViewController.m; sourceTree = "<group>"; };
 		2DF201031811E31B00BAB170 /* AVCustomTagTableViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AVCustomTagTableViewController.xib; sourceTree = "<group>"; };
 		2DF201061811E35500BAB170 /* AVTagTextViewSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AVTagTextViewSpec.m; path = ../../Tests/AVTagTextViewSpec.m; sourceTree = "<group>"; };
+		382BCD2C18C9DD5000F35CB3 /* AVMainViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVMainViewController.h; sourceTree = "<group>"; };
+		382BCD2D18C9DD5000F35CB3 /* AVMainViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVMainViewController.m; sourceTree = "<group>"; };
 		3CAF57F86D3B49F3BF0A0471 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 		8734AF505AF74CD9BF980484 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DACF7587EEA47368BAFD0A5 /* libPods-AVTagTextViewTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AVTagTextViewTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -135,6 +138,8 @@
 				2D4D932C1811DEBF00903297 /* AVAppDelegate.h */,
 				2D4D932D1811DEBF00903297 /* AVAppDelegate.m */,
 				2D4D932F1811DEBF00903297 /* Main.storyboard */,
+				382BCD2C18C9DD5000F35CB3 /* AVMainViewController.h */,
+				382BCD2D18C9DD5000F35CB3 /* AVMainViewController.m */,
 				2D4D93321811DEBF00903297 /* AVViewController.h */,
 				2D4D93331811DEBF00903297 /* AVViewController.m */,
 				2D4D93351811DEBF00903297 /* Images.xcassets */,
@@ -341,6 +346,7 @@
 				2DF201041811E31B00BAB170 /* AVCustomTagTableViewController.m in Sources */,
 				2D4D932A1811DEBF00903297 /* main.m in Sources */,
 				2D4D93341811DEBF00903297 /* AVViewController.m in Sources */,
+				382BCD2E18C9DD5000F35CB3 /* AVMainViewController.m in Sources */,
 				2D4D932E1811DEBF00903297 /* AVAppDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Project/AVTagTextView/AVMainViewController.h
+++ b/Project/AVTagTextView/AVMainViewController.h
@@ -1,0 +1,13 @@
+//
+//  AVMainViewController.h
+//  AVTagTextView
+//
+//  Created by amb on 07/03/14.
+//  Copyright (c) 2014 Arseniy Vershinin. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AVMainViewController : UIViewController
+
+@end

--- a/Project/AVTagTextView/AVMainViewController.m
+++ b/Project/AVTagTextView/AVMainViewController.m
@@ -1,0 +1,19 @@
+//
+//  AVMainViewController.m
+//  AVTagTextView
+//
+//  Created by amb on 07/03/14.
+//  Copyright (c) 2014 Arseniy Vershinin. All rights reserved.
+//
+
+#import "AVMainViewController.h"
+
+@implementation AVMainViewController
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self performSegueWithIdentifier:@"demoSegue" sender:nil];
+}
+
+@end

--- a/Project/AVTagTextView/AVViewController.m
+++ b/Project/AVTagTextView/AVViewController.m
@@ -29,6 +29,7 @@
     self.textView.delegate = self;
     self.textView.hashTagsDelegate = self;
     self.textView.hashTagsTableViewHeight = 120.;
+    self.textView.keyboardType = UIKeyboardTypeTwitter;
     //Provide a custom implementation of the hash tags table view (optional)
     //self.textView.hashTagsTableViewController = [AVCustomTagTableViewController new];
 }

--- a/Project/AVTagTextView/AVViewController.m
+++ b/Project/AVTagTextView/AVViewController.m
@@ -28,6 +28,7 @@
     //Set up the first text view with the default table view
     self.textView.delegate = self;
     self.textView.hashTagsDelegate = self;
+    self.textView.parentViewController = self;
     self.textView.hashTagsTableViewHeight = 120.;
     self.textView.keyboardType = UIKeyboardTypeTwitter;
     //Provide a custom implementation of the hash tags table view (optional)

--- a/Project/AVTagTextView/Base.lproj/Main.storyboard
+++ b/Project/AVTagTextView/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4510" systemVersion="12E55" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="gMG-SX-sa5">
     <dependencies>
-        <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
+        <deployment defaultVersion="1552" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -40,7 +40,37 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="498" y="68"/>
+            <point key="canvasLocation" x="661" y="81"/>
+        </scene>
+        <!--Main View Controller-->
+        <scene sceneID="hBR-9I-55a">
+            <objects>
+                <viewController id="gMG-SX-sa5" customClass="AVMainViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Hyn-DX-QRK"/>
+                        <viewControllerLayoutGuide type="bottom" id="4AT-hF-jqK"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ixY-5d-7DM">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="AVTagTextView" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CFZ-8K-E16">
+                                <rect key="frame" x="0.0" y="273" width="320" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                    <connections>
+                        <segue destination="2" kind="modal" identifier="demoSegue" id="Je4-43-SAx"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iOL-vV-aUM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="129" y="81"/>
         </scene>
     </scenes>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">

--- a/Project/Podfile.lock
+++ b/Project/Podfile.lock
@@ -23,8 +23,8 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  AVTagTextView: ac14f248f921cefd7a99cf2bd257a343fa01716e
+  AVTagTextView: d7c4170cfcbf76b084990f75ea1d0a3dab1bafbd
   Kiwi: 03539aeb004ccd42bdbc31253617b26364315df4
   ReactiveCocoa: 0142b823f4737effe6100f9fbb0a43bdcb629aae
 
-COCOAPODS: 0.26.2
+COCOAPODS: 0.29.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Version](http://cocoapod-badges.herokuapp.com/v/AVTagTextView/badge.png)](http://cocoadocs.org/docsets/AVTagTextView)
 [![Platform](http://cocoapod-badges.herokuapp.com/p/AVTagTextView/badge.png)](http://cocoadocs.org/docsets/AVTagTextView)
 
-A category that adds an instragram-like hashtag choosing/listing capability to the UITextView.
+A category that adds an instragram-like hashtag choosing/listing capability to the ```UITextView```.
 
 ![Screencapture GIF](https://dl.dropboxusercontent.com/u/31058381/OpenSource/AVTagTextView/out.gif)
 
@@ -47,7 +47,14 @@ self.textView.hashTagsDelegate = self;
 }
 ```
 
-Hashtags, contained in the UITextView, can be accessed through its hashTags property:
+Set the view controller where the hashtag table view will be displayed. Usually
+it will be the view controller that adds the `UITextView`
+
+```objc
+self.textView.parentViewController = self;
+```
+
+Hashtags, contained in the `UITextView`, can be accessed through its hashTags property:
 
 ```objc
 self.textView.hashTags //returns an array of strings, corresponding to the hash tags, found in the UITextView's text


### PR DESCRIPTION
Added a property to UITextView category to set the view controller where the hashtag table view will be displayed. In previous implementation, the hash tag table view wouldn't be displayed when using the category in a modal presented view controller or another view controller different from the root accessible from ApplicationDelegate.
